### PR TITLE
(GH-17) Fixing codecov-exe returning error code 1 on success

### DIFF
--- a/Source/Codecov/Program/Run.cs
+++ b/Source/Codecov/Program/Run.cs
@@ -17,7 +17,7 @@ namespace Codecov.Program
             {
                 Init(args);
                 Uploader();
-                return _kill;
+                return 0;
             }
             catch (Exception e)
             {


### PR DESCRIPTION
As I mentioned, just a one line change.

with this change the program will return a success code when no
exception occurs instead of the previous error code of 1.

fixes #17