### PR TITLE
(GH-22) Git interaction fails if project located at path with spaces

### DIFF
--- a/Source/Codecov/Services/VersionControlSystems/Git.cs
+++ b/Source/Codecov/Services/VersionControlSystems/Git.cs
@@ -103,6 +103,6 @@ namespace Codecov.Services.VersionControlSystems
             return string.IsNullOrWhiteSpace(sourceCode) ? Enumerable.Empty<string>() : sourceCode.Trim('\n').Split('\n').Select(FileSystem.NormalizedPath);
         }
 
-        private string RunGit(string commandArguments) => Terminal.Run("git", $"-C {RepoRoot} {commandArguments}");
+        private string RunGit(string commandArguments) => Terminal.Run("git", $"-C \"{RepoRoot}\" {commandArguments}");
     }
 }


### PR DESCRIPTION
If GIT repo is located at path with spaces (`D:\My Documents\My Repos\...`) then any call to `git` executable fails because `RepoRoot` is not recognized as single parameter.

Value should be quoted (on Windows, not sure about other platforms).