### PR TITLE
Normalize repo files to repo root instead of working directory.

### DIFF
--- a/Source/Codecov/Services/VersionControlSystems/Git.cs
+++ b/Source/Codecov/Services/VersionControlSystems/Git.cs
@@ -100,7 +100,7 @@ namespace Codecov.Services.VersionControlSystems
         private IEnumerable<string> LoadSourceCode()
         {
             var sourceCode = RunGit("ls-tree --full-tree -r HEAD --name-only");
-            return string.IsNullOrWhiteSpace(sourceCode) ? Enumerable.Empty<string>() : sourceCode.Trim('\n').Split('\n').Select(FileSystem.NormalizedPath);
+            return string.IsNullOrWhiteSpace(sourceCode) ? Enumerable.Empty<string>() : sourceCode.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).Select(p => Path.Combine(RepoRoot, p)).Select(FileSystem.NormalizedPath);
         }
 
         private string RunGit(string commandArguments) => Terminal.Run("git", $@"-C ""{RepoRoot}"" {commandArguments}");


### PR DESCRIPTION
codecov-exe is normalizing paths to repo files relative to its working directory instead of the repo root. This results in its working directory being prepended to the paths of repo files resulting in incorrect paths. See this [build log](https://codecov.s3.amazonaws.com/v4/raw/2018-01-26/0EC8C52F5558014AEF6DB23E9E6234D5/4e12ae5f6ff0218869e3e9910a0c41ce256a2518/6f9b7405-99e6-42c6-b1a3-7aa960fd1479.txt) for an example. All file paths start with `test\toofz.Build.Tests\` but should not.

This PR fixes it by getting the full paths to repo files before they are further processed.

Note: I haven't managed to test if the actual reports are corrected on Codecov because I'm getting a Bad Request response on submission.