### PR TITLE
-f and -e command line arguments don't accept multiple values as the docs suggest

### DIFF
--- a/Source/Codecov/Program/CommandLineOptions.cs
+++ b/Source/Codecov/Program/CommandLineOptions.cs
@@ -60,7 +60,7 @@ namespace Codecov.Program
         /// A value specifing the enviornment variables to be included with this build. (1)
         /// CODECOV_ENV=VAR1,VAR2. (2) -e VAR1 VAR2.
         /// </value>
-        [Option('e', "env", HelpText = "Specify enviornment variables to be included with this build. (1) CODECOV_ENV=VAR1,VAR2. (2) -e VAR1 VAR2.")]
+        [Option('e', "env", Separator = ' ', HelpText = "Specify enviornment variables to be included with this build. (1) CODECOV_ENV=VAR1,VAR2. (2) -e VAR1 VAR2.")]
         public IEnumerable<string> Envs { get; set; }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace Codecov.Program
         /// A value specifing the target file(s) to upload. (1) -f 'path/to/file'. Only upload this
         /// file. (2) -f 'path/to/file1 path/to/file2'. Only upload these files.
         /// </value>
-        [Option('f', "file", HelpText = "Target file(s) to upload. (1) -f 'path/to/file'. Only upload this file. (2) -f 'path/to/file1 path/to/file2'. Only upload these files.")]
+        [Option('f', "file", Separator = ' ', HelpText = "Target file(s) to upload. (1) -f 'path/to/file'. Only upload this file. (2) -f 'path/to/file1 path/to/file2'. Only upload these files.")]
         public IEnumerable<string> Files { get; set; }
 
         /// <summary>


### PR DESCRIPTION
`CommandLineOptions.cs` suggests the following command line `codecov -f a b c d` would detect and upload the 4 reports a, b, c & d. However, this doesn't work. 

CommandLineParser didn't seem to split the values without specifying the `Seperator` attribute. I have added `Seperator = ' '` attribute to both these options.