### PR TITLE
Add global tool

### DIFF
--- a/Source/Codecov/Codecov.Tool.csproj
+++ b/Source/Codecov/Codecov.Tool.csproj
@@ -1,0 +1,47 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <AssemblyName>codecov</AssemblyName>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <DebugType>pdbonly</DebugType>
+    <CheckForOverflowUnderflow Condition="'$(Configuration)' == 'Release'">true</CheckForOverflowUnderflow>
+    <CodeAnalysisRuleSet>.\Codecov.ruleset</CodeAnalysisRuleSet>
+    <PackageId>Codecov.Tool</PackageId>
+    <ToolCommandName>codecov</ToolCommandName>
+    <PackAsTool>true</PackAsTool>
+    <Authors>admiringworm;mathphysics</Authors>
+    <PackageLicenseUrl>https://github.com/codecov/codecov-exe/blob/master/LICENSE.txt</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/codecov/codecov-exe</PackageProjectUrl>
+    <PackageIconUrl>https://cdn.rawgit.com/codecov/media/0953f4e0d5315fb6d526a248bc88e1bc16506a37/logos/pink.png</PackageIconUrl>
+    <Description>Codecov global executable uploader.</Description>
+    <Copyright>Copyright (c) 2017-Present Larz White, Kim J. Nordmo</Copyright>
+    <PackageReleaseNotes>All release notes for Codecov can be found on the GitHub site - https://github.com/codecov/codecov-exe/releases/tag/$(Version)</PackageReleaseNotes>
+    <PackageTags>coverage;codecov</PackageTags>
+    <RepositoryUrl>https://github.com/codecov/codecov-exe</RepositoryUrl>
+  </PropertyGroup>  
+
+  <ItemGroup>
+    <Compile Remove="Scripts\**" />
+    <EmbeddedResource Remove="Scripts\**" />
+    <None Remove="Scripts\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.2.1" />
+    <PackageReference Include="Serilog" Version="2.7.1" />
+    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="All" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Contributes to https://github.com/codecov/codecov-exe/issues/44

@AdmiringWorm You probably want to add this project to your CI. For now I suggest do a one-off package upload:

```
cd Source\Codecov\
dotnet pack /p:PackageVersion=1.0.0
```

Upload the generated NuGet package. The global tool can be advertised to be the preferred solution for all operating systems. The only requirement is an installed .NET Core SDK.