### PR TITLE
Fix terminal filter

### DIFF
--- a/Source/Codecov/Factories/TerminalFactory.cs
+++ b/Source/Codecov/Factories/TerminalFactory.cs
@@ -8,17 +8,7 @@ namespace Codecov.Factories
     {
         public static IDictionary<TerminalName, ITerminal> Create()
         {
-            var terminals = new Dictionary<TerminalName, ITerminal> { { TerminalName.Generic, new Terminal.Terminal() }, { TerminalName.Powershell, new PowerShell() } };
-
-            foreach (var key in terminals.Keys.ToArray())
-            {
-                if (!terminals[key].Exits)
-                {
-                    terminals.Remove(key);
-                }
-            }
-
-            return terminals;
+            return new Dictionary<TerminalName, ITerminal> { { TerminalName.Generic, new Terminal.Terminal() }, { TerminalName.Powershell, new PowerShell() } };
         }
     }
 }

--- a/Source/Codecov/Factories/TerminalFactory.cs
+++ b/Source/Codecov/Factories/TerminalFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Codecov.Terminal;
 
 namespace Codecov.Factories
@@ -9,7 +10,7 @@ namespace Codecov.Factories
         {
             var terminals = new Dictionary<TerminalName, ITerminal> { { TerminalName.Generic, new Terminal.Terminal() }, { TerminalName.Powershell, new PowerShell() } };
 
-            foreach (var key in terminals.Keys)
+            foreach (var key in terminals.Keys.ToArray())
             {
                 if (!terminals[key].Exits)
                 {

--- a/Source/Codecov/Program/UploadFacade.cs
+++ b/Source/Codecov/Program/UploadFacade.cs
@@ -31,7 +31,7 @@ namespace Codecov.Program
 
         private ICoverage Coverage => new Coverage.Tool.Coverage(CommandLineCommandLineOptions);
 
-        private IUpload Upload => new Uploads(Url, Report, Terminals);
+        private IUpload Upload => new Uploads(Url, Report);
 
         private IUrl Url => new Url.Url(new Host(CommandLineCommandLineOptions), new Route(), new Query(CommandLineCommandLineOptions, Repositories, ContinuousIntegrationServer, Yaml));
 

--- a/Source/Codecov/Upload/Uploads.cs
+++ b/Source/Codecov/Upload/Uploads.cs
@@ -11,9 +11,9 @@ namespace Codecov.Upload
     {
         private readonly Lazy<IEnumerable<IUpload>> _uploaders;
 
-        public Uploads(IUrl url, IReport report, IDictionary<TerminalName, ITerminal> terminals)
+        public Uploads(IUrl url, IReport report)
         {
-            _uploaders = new Lazy<IEnumerable<IUpload>>(() => SetUploaders(url, report, terminals));
+            _uploaders = new Lazy<IEnumerable<IUpload>>(() => SetUploaders(url, report));
         }
 
         private IEnumerable<IUpload> Uploaders => _uploaders.Value;
@@ -34,16 +34,9 @@ namespace Codecov.Upload
             throw new Exception("Failed to upload the report.");
         }
 
-        private static IEnumerable<IUpload> SetUploaders(IUrl url, IReport report, IDictionary<TerminalName, ITerminal> terminals)
+        private static IEnumerable<IUpload> SetUploaders(IUrl url, IReport report)
         {
-            var uploaders = new List<IUpload> { new HttpWebRequest(url, report) };
-
-            if (terminals[TerminalName.Powershell].Exits)
-            {
-                uploaders.Add(new WebClient(url, report));
-            }
-
-            return uploaders;
+            return new List<IUpload> { new WebClient(url, report) };
         }
     }
 }


### PR DESCRIPTION
If a terminal is not available the following exception is thrown as a collection is modified in a foreach statement.

## Guidance
> The foreach statement is used to iterate through the collection to get the information that you want, but can not be used to add or remove items from the source collection to avoid unpredictable side effects. If you need to add or remove items from the source collection, use a for loop.

## Exception

              _____          _
             / ____|        | |
            | |     ___   __| | ___  ___ _____   __
            | |    / _ \ / _  |/ _ \/ __/ _ \ \ / /
            | |___| (_) | (_| |  __/ (_| (_) \ V /
             \_____\___/ \____|\___|\___\___/ \_/
                                         exe-1.2.0
            
2019-02-14 02:01:00 WRN No CI detected.
2019-02-14 02:01:01 FTL Collection was modified; enumeration operation may not execute.
   at System.Collections.Generic.Dictionary`2.KeyCollection.Enumerator.MoveNext()
   at Codecov.Factories.TerminalFactory.Create()
   at Codecov.Program.UploadFacade.get_VersionControlSystem()
   at Codecov.Program.UploadFacade.Uploader()
   at Codecov.Program.Run.Runner(IEnumerable`1 args)

## Fix
Iterating on a temporary array instead of the collection directly.