### PR TITLE
Make the HttpWebRequest provide more details for Put failures

### DIFF
--- a/Source/Codecov/Upload/HttpWebRequest.cs
+++ b/Source/Codecov/Upload/HttpWebRequest.cs
@@ -55,7 +55,14 @@ namespace Codecov.Upload
             }
 
             var putResponse = (HttpWebResponse)putRequest.GetResponseAsync().Result;
-            return putResponse.StatusCode == HttpStatusCode.OK;
+
+            if (putResponse.StatusCode != HttpStatusCode.OK)
+            {
+                Log.Verboase($"Cannot send to {url}. Received {putResponse.StatusCode}");
+                return false;
+            }
+
+            return true;
         }
     }
 }


### PR DESCRIPTION
I kept receiving error messages such as this when I upgraded to 1.3.0 and trying to diagnose issues:

> 2019-03-20 23:57:44 FTL Failed to upload the report.
>    at Codecov.Upload.Uploads.Uploader() in C:\source\codecov\codecov-exe\Source\Codecov\Upload\Uploads.cs:line 34
>    at Codecov.Program.UploadFacade.Uploader() in C:\source\codecov\codecov-exe\Source\Codecov\Program\UploadFacade.cs:line 119
>    at Codecov.Program.Run.Runner(IEnumerable`1 args) in C:\source\codecov\codecov-exe\Source\Codecov\Program\Run.cs:line 20

I wasn't finding it that helpful so added a verbose mode that gave the HTTP Status Code as well in the logging.