### PR TITLE
Change the azure pipelines to return "custom" for the service.

### DIFF
--- a/Source/Codecov/Services/ContinuousIntegrationServers/AzurePipelines.cs
+++ b/Source/Codecov/Services/ContinuousIntegrationServers/AzurePipelines.cs
@@ -25,7 +25,7 @@ namespace Codecov.Services.ContinuousIntegrationServers
 
         public override string Pr => _pr.Value;
 
-        public override string Service => "azurepipelines";
+        public override string Service => "custom";
 
         public override string Slug => _slug.Value;
 


### PR DESCRIPTION
This fixes #55 

This changes the "Service" from "azurepipelines" to "custom", a value supported by the codecov website. Without this change it produces a 400 http status on the POST response.