### PR TITLE
Updates to support Linux

### DIFF
--- a/Source/Codecov.Tests/Utilities/PathFilterBuilderTests.cs
+++ b/Source/Codecov.Tests/Utilities/PathFilterBuilderTests.cs
@@ -1,0 +1,102 @@
+﻿using Codecov.Utilities;
+using FluentAssertions;
+using System.IO;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace Codecov.Tests.Utilities
+{
+    public class PathFilterBuilderTests
+    {
+        [Theory]
+        [MemberData(nameof(ExtensionFilterTestData))]
+        public void ExtensionFilter_Should_Return_True_When_ExtensionsMatch(string path, string extensionFilter, bool expected)
+        {
+            var filter = new PathFilterBuilder()
+                .FileHasExtension(extensionFilter)
+                .Build();
+
+            filter.Matches(path).Should().Be(expected);
+        }
+
+        public static TheoryData<string, string, bool> ExtensionFilterTestData
+        {
+            get
+            {
+                var data = new TheoryData<string, string, bool>();
+                data.Add(CreatePath("file.txt"), ".txt", true);
+                data.Add(CreatePath("file.txt"), ".jpg", false);
+                data.Add(CreatePath("file.TxT"), ".txt", true);
+                data.Add(CreatePath("file"), ".txt", false);
+                data.Add(CreatePath("file.txt"), "txt", false);
+
+                return data;
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(PathFilterTestData))]
+        public void PathFilter_Should_Return_True_When_ExtensionsMatch(string path, string subPath, bool expected)
+        {
+            var filter = new PathFilterBuilder()
+                .PathContains(subPath)
+                .Build();
+
+            filter.Matches(path).Should().Be(expected);
+        }
+        
+        public static TheoryData<string, string, bool> PathFilterTestData
+        {
+            get
+            {
+                var data = new TheoryData<string, string, bool>();
+                data.Add(CreatePath("ChildPath"), @"\Foo", true);
+                data.Add(CreatePath("ChildPath"), @"/Foo", true);
+                data.Add(CreatePath("ChildPath"), @"Foo/", true);
+                data.Add(CreatePath("ChildPath"), @"Foo", true);
+                data.Add(CreatePath("ChildPath"), @"Bar", false);
+                data.Add(CreatePath("ChildPath"), @"USERS/Foo", true);
+
+                return data;
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeFilterData))]
+        public void CompoundFilter_Should_Return_True_When_MatchIsFound(string path, string pathFilter, string fileFilter, bool expected)
+        {
+            var filter = new PathFilterBuilder()
+                .PathContains(pathFilter)
+                .FileHasExtension(fileFilter)
+                .Build();
+
+            filter.Matches(path).Should().Be(expected);
+        }
+
+        public static TheoryData<string, string, string, bool> CompositeFilterData
+        {
+            get
+            {
+                var data = new TheoryData<string, string, string, bool>();
+                data.Add(CreatePath("file.txt"), @"\Users", ".txt", true);
+                data.Add(CreatePath("file.txt"), @"\Groups", ".txt", true);
+                data.Add(CreatePath("file.txt"), @"\Groups", ".zip", false);
+                data.Add("", @"\Users", ".txt", false);
+
+                return data;
+            }
+        }
+
+        private static string CreatePath(string path)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return Path.Combine(@"C:\Users\Foo\Documents", path);
+            }
+            else
+            {
+                return Path.Combine(@"/users/Foo/files", path);
+            }
+        }
+    }
+}

--- a/Source/Codecov/Coverage/SourceCode/SourceCode.cs
+++ b/Source/Codecov/Coverage/SourceCode/SourceCode.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Codecov.Services.VersionControlSystems;
 using Codecov.Utilities;
@@ -12,6 +11,7 @@ namespace Codecov.Coverage.SourceCode
         private readonly Lazy<IEnumerable<string>> _getAll;
         private readonly Lazy<IEnumerable<string>> _getAllButCodecovIgnored;
         private readonly Lazy<string> _directory;
+        private IPathFilter _fileFilter;
 
         public SourceCode(IVersionControlSystem versionControlSystem)
         {
@@ -19,6 +19,8 @@ namespace Codecov.Coverage.SourceCode
             _getAll = new Lazy<IEnumerable<string>>(() => VersionControlSystem.SourceCode.Select(FileSystem.NormalizedPath));
             _getAllButCodecovIgnored = new Lazy<IEnumerable<string>>(LoadGetAllButCodecovIgnored);
             _directory = new Lazy<string>(() => VersionControlSystem.RepoRoot);
+
+            _fileFilter = BuildSourceFilter();
         }
 
         public IEnumerable<string> GetAll => _getAll.Value;
@@ -31,59 +33,63 @@ namespace Codecov.Coverage.SourceCode
 
         private IEnumerable<string> LoadGetAllButCodecovIgnored()
         {
-            var dirSeperator = Path.DirectorySeparatorChar;
-            return GetAll.Select(file => FileSystem.NormalizedPath(file))
-                .Where(file => !file.ToLower().Contains("/.git"))
-                .Where(file => !file.ToLower().Contains("/bin/debug"))
-                .Where(file => !file.ToLower().Contains("/bin/release"))
-                .Where(file => !file.ToLower().Contains("/obj/debug"))
-                .Where(file => !file.ToLower().Contains("/obj/release"))
-                .Where(file => !file.ToLower().Contains("/.vscode"))
-                .Where(file => !file.ToLower().Contains("/.vs"))
-                .Where(file => !file.ToLower().Contains("/obj/project.assets.json"))
-                .Where(file => !file.ToLower().EndsWith(".csproj.nuget.g.targets"))
-                .Where(file => !file.ToLower().EndsWith(".csproj.nuget.g.props"))
-                .Where(file => !Path.GetExtension(file).Equals(".csproj.nuget.g.props", StringComparison.OrdinalIgnoreCase))
-                .Where(file => !Path.GetExtension(file).Equals(".dll", StringComparison.OrdinalIgnoreCase))
-                .Where(file => !Path.GetExtension(file).Equals(".exe", StringComparison.OrdinalIgnoreCase))
-                .Where(file => !Path.GetExtension(file).Equals(".gif", StringComparison.OrdinalIgnoreCase))
-                .Where(file => !Path.GetExtension(file).Equals(".jpg", StringComparison.OrdinalIgnoreCase))
-                .Where(file => !Path.GetExtension(file).Equals(".jpeg", StringComparison.OrdinalIgnoreCase))
-                .Where(file => !Path.GetExtension(file).Equals(".md", StringComparison.OrdinalIgnoreCase))
-                .Where(file => !Path.GetExtension(file).Equals(".png", StringComparison.OrdinalIgnoreCase))
-                .Where(file => !Path.GetExtension(file).Equals(".psd", StringComparison.OrdinalIgnoreCase))
-                .Where(file => !Path.GetExtension(file).Equals(".ptt", StringComparison.OrdinalIgnoreCase))
-                .Where(file => !Path.GetExtension(file).Equals(".pptx", StringComparison.OrdinalIgnoreCase))
-                .Where(file => !Path.GetExtension(file).Equals(".numbers", StringComparison.OrdinalIgnoreCase))
-                .Where(file => !Path.GetExtension(file).Equals(".pages", StringComparison.OrdinalIgnoreCase))
-                .Where(file => !Path.GetExtension(file).Equals(".txt", StringComparison.OrdinalIgnoreCase))
-                .Where(file => !Path.GetExtension(file).Equals(".xlsx", StringComparison.OrdinalIgnoreCase))
-                .Where(file => !Path.GetExtension(file).Equals(".docx", StringComparison.OrdinalIgnoreCase))
-                .Where(file => !Path.GetExtension(file).Equals(".doc", StringComparison.OrdinalIgnoreCase))
-                .Where(file => !Path.GetExtension(file).Equals(".pdf", StringComparison.OrdinalIgnoreCase))
-                .Where(file => !Path.GetExtension(file).Equals(".yml", StringComparison.OrdinalIgnoreCase))
-                .Where(file => !Path.GetExtension(file).Equals(".yaml", StringComparison.OrdinalIgnoreCase))
-                .Where(file => !Path.GetExtension(file).Equals(".gitignore", StringComparison.OrdinalIgnoreCase))
-                .Where(file => !file.ToLower().Contains("/virtualenv"))
-                .Where(file => !file.ToLower().Contains("/.virtualenv"))
-                .Where(file => !file.ToLower().Contains("/virtualenvs"))
-                .Where(file => !file.ToLower().Contains("/.virtualenvs"))
-                .Where(file => !file.ToLower().Contains("/env"))
-                .Where(file => !file.ToLower().Contains("/.env"))
-                .Where(file => !file.ToLower().Contains("/envs"))
-                .Where(file => !file.ToLower().Contains("/.envs"))
-                .Where(file => !file.ToLower().Contains("/venv"))
-                .Where(file => !file.ToLower().Contains("/.venv"))
-                .Where(file => !file.ToLower().Contains("/venvs"))
-                .Where(file => !file.ToLower().Contains("/.venvs"))
-                .Where(file => !file.ToLower().Contains("/build/lib"))
-                .Where(file => !file.ToLower().Contains("/.egg-info"))
-                .Where(file => !file.ToLower().Contains("/shunit2-2.1.6"))
-                .Where(file => !file.ToLower().Contains("/vendor"))
-                .Where(file => !file.ToLower().Contains("/js/generated/coverage"))
-                .Where(file => !file.ToLower().Contains("/__pycache__"))
-                .Where(file => !file.ToLower().Contains("/__pycache__"))
-                .Where(file => !file.ToLower().Contains("/node_modules"));
+            return GetAll.Where(file => !_fileFilter.Matches(file));
+        }
+
+        private static IPathFilter BuildSourceFilter()
+        {
+            return new PathFilterBuilder()
+                .PathContains(@"\.git")
+                .PathContains(@"\bin\debug")
+                .PathContains(@"\bin\release")
+                .PathContains(@"\obj\debug")
+                .PathContains(@"\obj\release")
+                .PathContains(@"\.vscode")
+                .PathContains(@"\.vs")
+                .PathContains(@"\obj\project.assets.json")
+                .PathContains(@"\virtualenv")
+                .PathContains(@"\.virtualenv")
+                .PathContains(@"\virtualenvs")
+                .PathContains(@"\.virtualenvs")
+                .PathContains(@"\env")
+                .PathContains(@"\.env")
+                .PathContains(@"\envs")
+                .PathContains(@"\.envs")
+                .PathContains(@"\venv")
+                .PathContains(@"\.venv")
+                .PathContains(@"\venvs")
+                .PathContains(@"\.venvs")
+                .PathContains(@"\build\lib")
+                .PathContains(@"\.egg-info")
+                .PathContains(@"\shunit2-2.1.6")
+                .PathContains(@"\vendor")
+                .PathContains(@"\js\generated\coverage")
+                .PathContains(@"\__pycache__")
+                .PathContains(@"\__pycache__")
+                .PathContains(@"\node_modules")
+                .PathContains(@".csproj.nuget.g.targets")
+                .PathContains(".csproj.nuget.g.props")
+                .HasExtension(".dll")
+                .HasExtension(".exe")
+                .HasExtension(".gif")
+                .HasExtension(".jpg")
+                .HasExtension(".jpeg")
+                .HasExtension(".md")
+                .HasExtension(".png")
+                .HasExtension(".psd")
+                .HasExtension(".ptt")
+                .HasExtension(".pptx")
+                .HasExtension(".numbers")
+                .HasExtension(".pages")
+                .HasExtension(".txt")
+                .HasExtension(".xlsx")
+                .HasExtension(".docx")
+                .HasExtension(".doc")
+                .HasExtension(".pdf")
+                .HasExtension(".yml")
+                .HasExtension(".yaml")
+                .HasExtension(".gitignore")
+                .Build();
         }
     }
 }

--- a/Source/Codecov/Coverage/SourceCode/SourceCode.cs
+++ b/Source/Codecov/Coverage/SourceCode/SourceCode.cs
@@ -11,7 +11,7 @@ namespace Codecov.Coverage.SourceCode
         private readonly Lazy<IEnumerable<string>> _getAll;
         private readonly Lazy<IEnumerable<string>> _getAllButCodecovIgnored;
         private readonly Lazy<string> _directory;
-        private IPathFilter _fileFilter;
+        private readonly IPathFilter _fileFilter;
 
         public SourceCode(IVersionControlSystem versionControlSystem)
         {
@@ -69,26 +69,26 @@ namespace Codecov.Coverage.SourceCode
                 .PathContains(@"\node_modules")
                 .PathContains(@".csproj.nuget.g.targets")
                 .PathContains(".csproj.nuget.g.props")
-                .HasExtension(".dll")
-                .HasExtension(".exe")
-                .HasExtension(".gif")
-                .HasExtension(".jpg")
-                .HasExtension(".jpeg")
-                .HasExtension(".md")
-                .HasExtension(".png")
-                .HasExtension(".psd")
-                .HasExtension(".ptt")
-                .HasExtension(".pptx")
-                .HasExtension(".numbers")
-                .HasExtension(".pages")
-                .HasExtension(".txt")
-                .HasExtension(".xlsx")
-                .HasExtension(".docx")
-                .HasExtension(".doc")
-                .HasExtension(".pdf")
-                .HasExtension(".yml")
-                .HasExtension(".yaml")
-                .HasExtension(".gitignore")
+                .FileHasExtension(".dll")
+                .FileHasExtension(".exe")
+                .FileHasExtension(".gif")
+                .FileHasExtension(".jpg")
+                .FileHasExtension(".jpeg")
+                .FileHasExtension(".md")
+                .FileHasExtension(".png")
+                .FileHasExtension(".psd")
+                .FileHasExtension(".ptt")
+                .FileHasExtension(".pptx")
+                .FileHasExtension(".numbers")
+                .FileHasExtension(".pages")
+                .FileHasExtension(".txt")
+                .FileHasExtension(".xlsx")
+                .FileHasExtension(".docx")
+                .FileHasExtension(".doc")
+                .FileHasExtension(".pdf")
+                .FileHasExtension(".yml")
+                .FileHasExtension(".yaml")
+                .FileHasExtension(".gitignore")
                 .Build();
         }
     }

--- a/Source/Codecov/Services/VersionControlSystems/Git.cs
+++ b/Source/Codecov/Services/VersionControlSystems/Git.cs
@@ -58,7 +58,7 @@ namespace Codecov.Services.VersionControlSystems
 
         private bool LoadDetecter()
         {
-            return !string.IsNullOrWhiteSpace(Terminal.Run("git", "--version")) && Directory.Exists($"{RepoRoot}/.git");
+            return !string.IsNullOrWhiteSpace(Terminal.Run("git", "--version")) && Directory.Exists(Path.Combine(RepoRoot, ".git"));
         }
 
         private string LoadRepoRoot()
@@ -100,7 +100,9 @@ namespace Codecov.Services.VersionControlSystems
         private IEnumerable<string> LoadSourceCode()
         {
             var sourceCode = RunGit("ls-tree --full-tree -r HEAD --name-only");
-            return string.IsNullOrWhiteSpace(sourceCode) ? Enumerable.Empty<string>() : sourceCode.Trim('\n').Split('\n').Select(FileSystem.NormalizedPath);
+            return string.IsNullOrWhiteSpace(sourceCode) ?
+                Enumerable.Empty<string>()
+                : sourceCode.Trim('\n').Split('\n').Select(FileSystem.NormalizedPath);
         }
 
         private string RunGit(string commandArguments) => Terminal.Run("git", $@"-C ""{RepoRoot}"" {commandArguments}");

--- a/Source/Codecov/Services/VersionControlSystems/Git.cs
+++ b/Source/Codecov/Services/VersionControlSystems/Git.cs
@@ -102,7 +102,7 @@ namespace Codecov.Services.VersionControlSystems
             var sourceCode = RunGit("ls-tree --full-tree -r HEAD --name-only");
             return string.IsNullOrWhiteSpace(sourceCode) ?
                 Enumerable.Empty<string>()
-                : sourceCode.Trim('\n').Split('\n').Select(FileSystem.NormalizedPath);
+                : sourceCode.Trim('\n').Split('\n').Select(file => FileSystem.NormalizedPath(Path.Combine(RepoRoot, file)));
         }
 
         private string RunGit(string commandArguments) => Terminal.Run("git", $@"-C ""{RepoRoot}"" {commandArguments}");

--- a/Source/Codecov/Utilities/IPathFilter.cs
+++ b/Source/Codecov/Utilities/IPathFilter.cs
@@ -1,0 +1,7 @@
+﻿namespace Codecov.Utilities
+{
+    internal interface IPathFilter
+    {
+        bool Matches(string path);
+    }
+}

--- a/Source/Codecov/Utilities/PathFilterBuilder.cs
+++ b/Source/Codecov/Utilities/PathFilterBuilder.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+
+namespace Codecov.Utilities
+{
+    internal class PathFilterBuilder
+    {
+        private readonly List<IPathFilter> _filters = new List<IPathFilter>();
+
+        public PathFilterBuilder HasExtension(string extension)
+        {
+            _filters.Add(new FileExtensionPathFilter(extension));
+            return this;
+        }
+
+        public PathFilterBuilder FileNameMatches(string pattern)
+        {
+            _filters.Add(new FileNameFilter(pattern));
+            return this;
+        }
+
+        public PathFilterBuilder PathContains(string path)
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                path = path.Replace(@"\", "/");
+            }
+
+            _filters.Add(new PathFilter(path));
+            return this;
+        }
+
+        public IPathFilter Build()
+        {
+            return new CompositePathFilter(_filters);
+        }
+
+        private class PathFilter : IPathFilter
+        {
+            private readonly string _subPath;
+
+            public PathFilter(string subPath)
+            {
+                _subPath = subPath;
+            }
+
+            public bool Matches(string path)
+            {
+                return path.Contains(_subPath, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        private class FileExtensionPathFilter : IPathFilter
+        {
+            private readonly string _extension;
+
+            public FileExtensionPathFilter(string extension)
+            {
+                _extension = extension;
+            }
+
+            public bool Matches(string path)
+            {
+                var fileExtension = Path.GetExtension(path);
+
+                return _extension.Equals(fileExtension, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        private class FileNameFilter : IPathFilter
+        {
+            private readonly Regex _regex;
+
+            public FileNameFilter(string regex)
+            {
+                _regex = new Regex(regex, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            }
+
+            public bool Matches(string path)
+            {
+                var filename = Path.GetFileName(path);
+                return _regex.IsMatch(filename);
+            }
+        }
+        
+        private class CompositePathFilter : IPathFilter
+        {
+            private readonly List<IPathFilter> _filters;
+
+            public CompositePathFilter(List<IPathFilter> filters)
+            {
+                _filters = filters;
+            }
+
+
+            public bool Matches(string path)
+            {
+                return _filters.Any(f => f.Matches(path));
+            }
+        }
+    }
+}


### PR DESCRIPTION

* Reworked the file filtering to be cross platform.   Long term it may be best to make the filtering configurable.

* Fix logic in Report to create relative paths in a platform neutral way.

* Update Git logic to use System.IO.Path and also use the "Git Root" to create the absolute path, otherwise we end up with an absolute path from the current working directory.

With these changes I'm able to reliably push to codecov and view the coverage reports.  Without getting path errors.