### PR TITLE
Set all properties for Azure Pipelines uploads

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,2 @@
+<Project>
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,2 @@
+<Project>
+</Project>

--- a/Source/Codecov.Tests/Services/ContiniousIntegrationServers/AzurePipelinesTests.cs
+++ b/Source/Codecov.Tests/Services/ContiniousIntegrationServers/AzurePipelinesTests.cs
@@ -35,6 +35,7 @@ namespace Codecov.Tests.Services.ContiniousIntegrationServers
         public void Branch_Should_Be_Empty_String_When_Enviornment_Variable_Does_Not_Exits()
         {
             // Given
+            Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_TARGETBRANCH", null);
             Environment.SetEnvironmentVariable("BUILD_SOURCEBRANCHNAME", null);
             var pipelines = new AzurePipelines();
 
@@ -46,9 +47,25 @@ namespace Codecov.Tests.Services.ContiniousIntegrationServers
         }
 
         [Fact]
-        public void Branch_Should_Be_Set_When_Enviornment_Variable_Exits()
+        public void Branch_Should_Be_Set_When_PR_Enviornment_Variable_Exits()
         {
             // Given
+            Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_TARGETBRANCH", "develop");
+            Environment.SetEnvironmentVariable("BUILD_SOURCEBRANCHNAME", null);
+            var pipelines = new AzurePipelines();
+
+            // When
+            var branch = pipelines.Branch;
+
+            // Then
+            branch.Should().Be("develop");
+        }
+
+        [Fact]
+        public void Branch_Should_Be_Set_When_Branch_Enviornment_Variable_Exits()
+        {
+            // Given
+            Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_TARGETBRANCH", null);
             Environment.SetEnvironmentVariable("BUILD_SOURCEBRANCHNAME", "develop");
             var pipelines = new AzurePipelines();
 
@@ -57,6 +74,21 @@ namespace Codecov.Tests.Services.ContiniousIntegrationServers
 
             // Then
             branch.Should().Be("develop");
+        }
+
+        [Fact]
+        public void Branch_Should_Prefer_Pull_Request()
+        {
+            // Given
+            Environment.SetEnvironmentVariable("SYSTEM_PULLREQUEST_TARGETBRANCH", "pr");
+            Environment.SetEnvironmentVariable("BUILD_SOURCEBRANCHNAME", "master");
+            var pipelines = new AzurePipelines();
+
+            // When
+            var branch = pipelines.Branch;
+
+            // Then
+            branch.Should().Be("pr");
         }
 
         [Fact]

--- a/Source/Codecov.Tests/Services/ContiniousIntegrationServers/AzurePipelinesTests.cs
+++ b/Source/Codecov.Tests/Services/ContiniousIntegrationServers/AzurePipelinesTests.cs
@@ -63,7 +63,7 @@ namespace Codecov.Tests.Services.ContiniousIntegrationServers
         public void Build_Should_Be_Empty_String_When_Enviornment_Variable_Does_Not_Exits()
         {
             // Given
-            Environment.SetEnvironmentVariable("BUILD_BUILDID", null);
+            Environment.SetEnvironmentVariable("BUILD_BUILDNUMBER", null);
             var pipelines = new AzurePipelines();
 
             // When
@@ -77,7 +77,7 @@ namespace Codecov.Tests.Services.ContiniousIntegrationServers
         public void Build_Should_Be_Set_When_Enviornment_Variable_Exits()
         {
             // Given
-            Environment.SetEnvironmentVariable("BUILD_BUILDID", "123");
+            Environment.SetEnvironmentVariable("BUILD_BUILDNUMBER", "123");
             var pipelines = new AzurePipelines();
 
             // When
@@ -180,12 +180,12 @@ namespace Codecov.Tests.Services.ContiniousIntegrationServers
             buildUrl.Should().BeEmpty();
         }
 
-        [Theory, InlineData(null, null), InlineData("", ""), InlineData("foo", ""), InlineData("", "foo")]
+        [Theory, InlineData(null, null), InlineData("", ""), InlineData("foo", "")]
         public void Job_Should_Be_Empty_String_When_Enviornment_Variables_Do_Not_Exit(string slugData, string versionData)
         {
             // Given
             Environment.SetEnvironmentVariable("BUILD_REPOSITORY_NAME", slugData);
-            Environment.SetEnvironmentVariable("BUILD_BUILDNUMBER", versionData);
+            Environment.SetEnvironmentVariable("BUILD_BUILDID", versionData);
 
             var pipelines = new AzurePipelines();
 
@@ -201,14 +201,14 @@ namespace Codecov.Tests.Services.ContiniousIntegrationServers
         {
             // Given
             Environment.SetEnvironmentVariable("BUILD_REPOSITORY_NAME", "foo/bar");
-            Environment.SetEnvironmentVariable("BUILD_BUILDNUMBER", "bang");
+            Environment.SetEnvironmentVariable("BUILD_BUILDID", "bang");
             var pipelines = new AzurePipelines();
 
             // When
             var job = pipelines.Job;
 
             // Then
-            job.Should().Be("foo/bar/bang");
+            job.Should().Be("bang");
         }
 
         [Fact]

--- a/Source/Codecov.Tests/Services/ContiniousIntegrationServers/AzurePipelinesTests.cs
+++ b/Source/Codecov.Tests/Services/ContiniousIntegrationServers/AzurePipelinesTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Codecov.Services.ContinuousIntegrationServers;
 using FluentAssertions;
 using Xunit;
@@ -7,6 +8,29 @@ namespace Codecov.Tests.Services.ContiniousIntegrationServers
 {
     public class AzurePipelinesTests
     {
+        public static IEnumerable<object[]> Build_Url_Empty_Data
+        {
+            get
+            {
+                var possibleDomains = new[]{ null, string.Empty, "https://dev.azure.com/", "http://localhost:5234/" };
+                var possibleDummies = new[] { null, string.Empty, "foo", "bar" };
+
+                foreach (var domain in possibleDomains)
+                {
+                    foreach (var project in possibleDummies)
+                    {
+                        foreach (var build in possibleDummies)
+                        {
+                            if (string.IsNullOrEmpty(domain) || string.IsNullOrEmpty(project) || string.IsNullOrEmpty(build))
+                            {
+                                yield return new object[] { domain, project, build };
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         [Fact]
         public void Branch_Should_Be_Empty_String_When_Enviornment_Variable_Does_Not_Exits()
         {
@@ -105,6 +129,57 @@ namespace Codecov.Tests.Services.ContiniousIntegrationServers
             detecter.Should().BeFalse();
         }
 
+        [Theory, MemberData(nameof(Build_Url_Empty_Data))]
+        public void BuildUrl_Should_Be_Empty_String_When_Environment_Variables_Do_Not_Exist(string serverUrl, string project, string build)
+        {
+            // Given
+            Environment.SetEnvironmentVariable("SYSTEM_TEAMFOUNDATIONSERVERURI", serverUrl);
+            Environment.SetEnvironmentVariable("SYSTEM_TEAMPROJECT", project);
+            Environment.SetEnvironmentVariable("BUILD_BUILDID", build);
+
+            var pipelines = new AzurePipelines();
+
+            // When
+            var buildUrl = pipelines.BuildUrl;
+
+            // Then
+            buildUrl.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void BuildUrl_Should_Not_Empty_String_When_Environment_Variable_Exists()
+        {
+            // Given
+            Environment.SetEnvironmentVariable("SYSTEM_TEAMFOUNDATIONSERVERURI", "https://dev.azure.com/");
+            Environment.SetEnvironmentVariable("SYSTEM_TEAMPROJECT", "project");
+            Environment.SetEnvironmentVariable("BUILD_BUILDID", "build");
+
+            var pipelines = new AzurePipelines();
+
+            // When
+            var buildUrl = pipelines.BuildUrl;
+
+            // Then
+            buildUrl.Should().Be("https://dev.azure.com/project/_build/results?buildId=build");
+        }
+
+        [Theory, InlineData("http://"), InlineData("http://."), InlineData("http://.."), InlineData("http://../"), InlineData("http://?"), InlineData("http://??"), InlineData("http://#"), InlineData("http://##"), InlineData("//"), InlineData("//a"), InlineData("///a"), InlineData("///"), InlineData("foo.com"), InlineData("rdar://1234"), InlineData("h://test"), InlineData("http:// shouldfail.com"), InlineData(":// should fail"), InlineData("ftps://foo.bar/"), InlineData("http://.www.foo.bar/")]
+        public void BuildUrl_Should_Be_Empty_When_Appveyor_Url_Is_Invalid_Domain(string urlData)
+        {
+            // Given
+            Environment.SetEnvironmentVariable("SYSTEM_TEAMFOUNDATIONSERVERURI", urlData);
+            Environment.SetEnvironmentVariable("SYSTEM_TEAMPROJECT", "project");
+            Environment.SetEnvironmentVariable("BUILD_BUILDID", "build");
+
+            var pipelines = new AzurePipelines();
+
+            // When
+            var buildUrl = pipelines.BuildUrl;
+
+            // Then
+            buildUrl.Should().BeEmpty();
+        }
+
         [Theory, InlineData(null, null), InlineData("", ""), InlineData("foo", ""), InlineData("", "foo")]
         public void Job_Should_Be_Empty_String_When_Enviornment_Variables_Do_Not_Exit(string slugData, string versionData)
         {
@@ -162,6 +237,62 @@ namespace Codecov.Tests.Services.ContiniousIntegrationServers
 
             // Then
             pr.Should().Be("123");
+        }
+
+        [Fact]
+        public void Project_Should_Be_Empty_String_When_Enviornment_Variable_Does_Not_Exits()
+        {
+            // Given
+            Environment.SetEnvironmentVariable("SYSTEM_TEAMPROJECT", null);
+            var pipelines = new AzurePipelines();
+
+            // When
+            var project = pipelines.Project;
+
+            // Then
+            project.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Project_Should_Be_Set_When_Enviornment_Variable_Exits()
+        {
+            // Given
+            Environment.SetEnvironmentVariable("SYSTEM_TEAMPROJECT", "123");
+            var pipelines = new AzurePipelines();
+
+            // When
+            var project = pipelines.Project;
+
+            // Then
+            project.Should().Be("123");
+        }
+
+        [Fact]
+        public void ServerUri_Should_Be_Empty_String_When_Enviornment_Variable_Does_Not_Exits()
+        {
+            // Given
+            Environment.SetEnvironmentVariable("SYSTEM_TEAMFOUNDATIONSERVERURI", null);
+            var pipelines = new AzurePipelines();
+
+            // When
+            var serverUri = pipelines.ServerUri;
+
+            // Then
+            serverUri.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ServerUri_Should_Be_Set_When_Enviornment_Variable_Exits()
+        {
+            // Given
+            Environment.SetEnvironmentVariable("SYSTEM_TEAMFOUNDATIONSERVERURI", "123");
+            var pipelines = new AzurePipelines();
+
+            // When
+            var serverUri = pipelines.ServerUri;
+
+            // Then
+            serverUri.Should().Be("123");
         }
 
         [Fact]

--- a/Source/Codecov.Tests/Url/QueryTests.cs
+++ b/Source/Codecov.Tests/Url/QueryTests.cs
@@ -217,6 +217,8 @@ namespace Codecov.Tests.Url
             repository.Branch.Returns("develop");
             repository.Commit.Returns("3c075f8d15aea3b3b40cea0bcf441a30bfd5c5d2");
             repository.Pr.Returns("123");
+            repository.Project.Returns(string.Empty);
+            repository.ServerUri.Returns(string.Empty);
             repository.Tag.Returns("v1.0");
             repository.Slug.Returns("larz/codecov-exe");
             var build = Substitute.For<IBuild>();
@@ -230,6 +232,38 @@ namespace Codecov.Tests.Url
             getQuery.FirstOrDefault(x => x.StartsWith("branch=")).Should().Be("branch=develop");
             getQuery.FirstOrDefault(x => x.StartsWith("commit=")).Should().Be("commit=3c075f8d15aea3b3b40cea0bcf441a30bfd5c5d2");
             getQuery.FirstOrDefault(x => x.StartsWith("pr=")).Should().Be("pr=123");
+            getQuery.FirstOrDefault(x => x.StartsWith("project=")).Should().Be(null);
+            getQuery.FirstOrDefault(x => x.StartsWith("server_uri=")).Should().Be(null);
+            getQuery.FirstOrDefault(x => x.StartsWith("tag=")).Should().Be("tag=v1.0");
+            getQuery.FirstOrDefault(x => x.StartsWith("slug=")).Should().Be("slug=larz%2Fcodecov-exe");
+        }
+
+        [Fact]
+        public void Should_Set_From_Repository_WithProject()
+        {
+            // Given
+            var queryOptions = Substitute.For<IQueryOptions>();
+            var repository = Substitute.For<IRepository>();
+            repository.Branch.Returns("develop");
+            repository.Commit.Returns("3c075f8d15aea3b3b40cea0bcf441a30bfd5c5d2");
+            repository.Pr.Returns("123");
+            repository.Project.Returns("projectA");
+            repository.ServerUri.Returns("https://dev.azure.com/");
+            repository.Tag.Returns("v1.0");
+            repository.Slug.Returns("larz/codecov-exe");
+            var build = Substitute.For<IBuild>();
+            var yaml = Substitute.For<IYaml>();
+            var query = new Query(queryOptions, new[] { repository }, build, yaml);
+
+            // When
+            var getQuery = query.GetQuery.Split('&');
+
+            // Then
+            getQuery.FirstOrDefault(x => x.StartsWith("branch=")).Should().Be("branch=develop");
+            getQuery.FirstOrDefault(x => x.StartsWith("commit=")).Should().Be("commit=3c075f8d15aea3b3b40cea0bcf441a30bfd5c5d2");
+            getQuery.FirstOrDefault(x => x.StartsWith("pr=")).Should().Be("pr=123");
+            getQuery.FirstOrDefault(x => x.StartsWith("project=")).Should().Be("project=projectA");
+            getQuery.FirstOrDefault(x => x.StartsWith("server_uri=")).Should().Be("server_uri=https://dev.azure.com/");
             getQuery.FirstOrDefault(x => x.StartsWith("tag=")).Should().Be("tag=v1.0");
             getQuery.FirstOrDefault(x => x.StartsWith("slug=")).Should().Be("slug=larz%2Fcodecov-exe");
         }

--- a/Source/Codecov/Services/ContinuousIntegrationServers/AzurePipelines.cs
+++ b/Source/Codecov/Services/ContinuousIntegrationServers/AzurePipelines.cs
@@ -7,15 +7,25 @@ namespace Codecov.Services.ContinuousIntegrationServers
     {
         private readonly Lazy<string> _branch = new Lazy<string>(() => EnviornmentVariable.GetEnviornmentVariable("BUILD_SOURCEBRANCHNAME"));
         private readonly Lazy<string> _build = new Lazy<string>(LoadBuild);
+        private readonly Lazy<string> _buildUrl;
         private readonly Lazy<string> _commit = new Lazy<string>(() => EnviornmentVariable.GetEnviornmentVariable("BUILD_SOURCEVERSION"));
         private readonly Lazy<bool> _detecter = new Lazy<bool>(() => CheckEnvironmentVariables("TF_BUILD"));
         private readonly Lazy<string> _job = new Lazy<string>(LoadJob);
         private readonly Lazy<string> _pr = new Lazy<string>(() => EnviornmentVariable.GetEnviornmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER"));
+        private readonly Lazy<string> _project = new Lazy<string>(() => EnviornmentVariable.GetEnviornmentVariable("SYSTEM_TEAMPROJECT"));
+        private readonly Lazy<string> _serverUri = new Lazy<string>(() => EnviornmentVariable.GetEnviornmentVariable("SYSTEM_TEAMFOUNDATIONSERVERURI"));
         private readonly Lazy<string> _slug = new Lazy<string>(() => EnviornmentVariable.GetEnviornmentVariable("BUILD_REPOSITORY_NAME"));
+
+        public AzurePipelines()
+        {
+            _buildUrl = new Lazy<string>(LoadBuildUrl);
+        }
 
         public override string Branch => _branch.Value;
 
         public override string Build => _build.Value;
+
+        public override string BuildUrl => _buildUrl.Value;
 
         public override string Commit => _commit.Value;
 
@@ -24,6 +34,10 @@ namespace Codecov.Services.ContinuousIntegrationServers
         public override string Job => _job.Value;
 
         public override string Pr => _pr.Value;
+
+        public override string Project => _project.Value;
+
+        public override string ServerUri => _serverUri.Value;
 
         public override string Service => "azure_pipelines";
 
@@ -48,6 +62,25 @@ namespace Codecov.Services.ContinuousIntegrationServers
             var job = $"{slug}/{version}";
 
             return job;
+        }
+
+        private string LoadBuildUrl()
+        {
+            var serverUri = ServerUri;
+            var project = Project;
+            var build = Build;
+            if (string.IsNullOrEmpty(serverUri) || string.IsNullOrEmpty(project) || string.IsNullOrEmpty(build))
+            {
+                return string.Empty;
+            }
+
+            if (!Uri.TryCreate(serverUri, UriKind.Absolute, out var uri)
+                || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+            {
+                return string.Empty;
+            }
+
+            return $"{serverUri}{project}/_build/results?buildId={build}";
         }
     }
 }

--- a/Source/Codecov/Services/ContinuousIntegrationServers/AzurePipelines.cs
+++ b/Source/Codecov/Services/ContinuousIntegrationServers/AzurePipelines.cs
@@ -5,7 +5,7 @@ namespace Codecov.Services.ContinuousIntegrationServers
 {
     internal class AzurePipelines : ContinuousIntegrationServer
     {
-        private readonly Lazy<string> _branch = new Lazy<string>(() => EnviornmentVariable.GetEnviornmentVariable("BUILD_SOURCEBRANCHNAME"));
+        private readonly Lazy<string> _branch = new Lazy<string>(LoadBranch);
         private readonly Lazy<string> _build = new Lazy<string>(LoadBuild);
         private readonly Lazy<string> _buildUrl;
         private readonly Lazy<string> _commit = new Lazy<string>(() => EnviornmentVariable.GetEnviornmentVariable("BUILD_SOURCEVERSION"));
@@ -42,6 +42,17 @@ namespace Codecov.Services.ContinuousIntegrationServers
         public override string Service => "azure_pipelines";
 
         public override string Slug => _slug.Value;
+
+        private static string LoadBranch()
+        {
+            var pullRequestBranch = EnviornmentVariable.GetEnviornmentVariable("SYSTEM_PULLREQUEST_TARGETBRANCH");
+            if (!string.IsNullOrEmpty(pullRequestBranch))
+            {
+                return pullRequestBranch;
+            }
+
+            return EnviornmentVariable.GetEnviornmentVariable("BUILD_SOURCEBRANCHNAME");
+        }
 
         private static string LoadBuild()
         {

--- a/Source/Codecov/Services/ContinuousIntegrationServers/AzurePipelines.cs
+++ b/Source/Codecov/Services/ContinuousIntegrationServers/AzurePipelines.cs
@@ -10,7 +10,7 @@ namespace Codecov.Services.ContinuousIntegrationServers
         private readonly Lazy<string> _buildUrl;
         private readonly Lazy<string> _commit = new Lazy<string>(() => EnviornmentVariable.GetEnviornmentVariable("BUILD_SOURCEVERSION"));
         private readonly Lazy<bool> _detecter = new Lazy<bool>(() => CheckEnvironmentVariables("TF_BUILD"));
-        private readonly Lazy<string> _job = new Lazy<string>(LoadJob);
+        private readonly Lazy<string> _job = new Lazy<string>(() => EnviornmentVariable.GetEnviornmentVariable("BUILD_BUILDID"));
         private readonly Lazy<string> _pr = new Lazy<string>(() => EnviornmentVariable.GetEnviornmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER"));
         private readonly Lazy<string> _project = new Lazy<string>(() => EnviornmentVariable.GetEnviornmentVariable("SYSTEM_TEAMPROJECT"));
         private readonly Lazy<string> _serverUri = new Lazy<string>(() => EnviornmentVariable.GetEnviornmentVariable("SYSTEM_TEAMFOUNDATIONSERVERURI"));
@@ -45,30 +45,15 @@ namespace Codecov.Services.ContinuousIntegrationServers
 
         private static string LoadBuild()
         {
-            var build = EnviornmentVariable.GetEnviornmentVariable("BUILD_BUILDID");
+            var build = EnviornmentVariable.GetEnviornmentVariable("BUILD_BUILDNUMBER");
             return !string.IsNullOrWhiteSpace(build) ? Uri.EscapeDataString(build) : string.Empty;
-        }
-
-        private static string LoadJob()
-        {
-            var slug = EnviornmentVariable.GetEnviornmentVariable("BUILD_REPOSITORY_NAME");
-            var version = EnviornmentVariable.GetEnviornmentVariable("BUILD_BUILDNUMBER");
-
-            if (string.IsNullOrEmpty(slug) || string.IsNullOrEmpty(version))
-            {
-                return string.Empty;
-            }
-
-            var job = $"{slug}/{version}";
-
-            return job;
         }
 
         private string LoadBuildUrl()
         {
             var serverUri = ServerUri;
             var project = Project;
-            var build = Build;
+            var build = Job;
             if (string.IsNullOrEmpty(serverUri) || string.IsNullOrEmpty(project) || string.IsNullOrEmpty(build))
             {
                 return string.Empty;

--- a/Source/Codecov/Services/ContinuousIntegrationServers/ContinuousIntegrationServer.cs
+++ b/Source/Codecov/Services/ContinuousIntegrationServers/ContinuousIntegrationServer.cs
@@ -27,6 +27,10 @@ namespace Codecov.Services.ContinuousIntegrationServers
 
         public virtual string Pr => string.Empty;
 
+        public virtual string Project => string.Empty;
+
+        public virtual string ServerUri => string.Empty;
+
         public virtual string Service => string.Empty;
 
         public virtual string Slug => string.Empty;

--- a/Source/Codecov/Services/IRepository.cs
+++ b/Source/Codecov/Services/IRepository.cs
@@ -8,6 +8,10 @@
 
         string Pr { get; }
 
+        string Project { get; }
+
+        string ServerUri { get; }
+
         string Slug { get; }
 
         string Tag { get; }

--- a/Source/Codecov/Services/VersionControlSystems/VersionControlSystem.cs
+++ b/Source/Codecov/Services/VersionControlSystems/VersionControlSystem.cs
@@ -32,6 +32,10 @@ namespace Codecov.Services.VersionControlSystems
 
         public virtual string Pr => _pr.Value;
 
+        public virtual string Project => string.Empty;
+
+        public virtual string ServerUri => string.Empty;
+
         public virtual string RepoRoot => _repoRoot.Value;
 
         public virtual string Slug => _slug.Value;

--- a/Source/Codecov/Url/Query.cs
+++ b/Source/Codecov/Url/Query.cs
@@ -164,6 +164,19 @@ namespace Codecov.Url
             OverrideIfNotEmptyOrNull("pr", Options.Pr);
         }
 
+        private void SetProjectAndServerUri()
+        {
+            foreach (var repository in Repositories)
+            {
+                if (!string.IsNullOrEmpty(repository.Project) && !string.IsNullOrEmpty(repository.ServerUri))
+                {
+                    QueryParameters["project"] = repository.Project;
+                    QueryParameters["server_uri"] = repository.ServerUri;
+                    break;
+                }
+            }
+        }
+
         private void SetQueryParameters()
         {
             QueryParameters = new Dictionary<string, string>();
@@ -181,6 +194,7 @@ namespace Codecov.Url
             SetYaml();
             SetJob();
             SetService();
+            SetProjectAndServerUri();
         }
 
         private void SetService()


### PR DESCRIPTION
Make sure to set the `build_url`, `project`, and `server_uri` properties for Azure Pipelines. These properties allow the uploads to omit the codecov token.

The `build` and `job` values were also updated to match the values used by codecov-bash for Azure Pipelines.