### PR TITLE
Add new Codecov.MSBuild package providing a `Codecov`MSBuild task

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,15 +29,6 @@ jobs:
         uses: actions/setup-dotnet@v1.7.2
         with:
           dotnet-version: 3.1.300
-      - name: .net SxS Unix
-        if: matrix.os != 'windows-latest'
-        run: rsync -a ${DOTNET_ROOT/3.1.300/2.1.806}/* $DOTNET_ROOT/
-      - name: .net Sxs Windows
-        if: matrix.os == 'windows-latest'
-        run: |
-          SET DOTNET_31_ROOT=%DOTNET_ROOT:3.1.300=2.1.806%
-          xcopy /s /y /d %DOTNET_31_ROOT% %DOTNET_ROOT%
-        shell: cmd
       - name: Build with cake
         uses: cake-build/cake-action@v1.2.0
         with:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Build status](https://img.shields.io/appveyor/ci/AdmiringWorm/codecov-exe?logo=appveyor)](https://ci.appveyor.com/project/AdmiringWorm/codecov-exe)
 [![NuGet](https://img.shields.io/nuget/v/Codecov?logo=nuget)](https://www.nuget.org/packages/Codecov/)
 [![DotNet Tool](https://img.shields.io/nuget/v/Codecov.Tool?label=dotnet%20tool&logo=nuget)](https://www.nuget.org/packages/Codecov.Tool/)
+[![MSBuild Task](https://img.shields.io/nuget/v/Codecov.MSBuild?label=msbuild%20task&logo=nuget)](https://www.nuget.org/packages/Codecov.MSBuild/)
 [![Chocolatey](https://img.shields.io/chocolatey/v/codecov.svg)](https://chocolatey.org/packages/codecov)
 [![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg?maxAge=2592000&logo=gitter)](https://gitter.im/codecov-exe/community)
 [![codecov](https://codecov.io/gh/codecov/codecov-exe/branch/master/graph/badge.svg)](https://codecov.io/gh/codecov/codecov-exe)
@@ -61,6 +62,20 @@ codecov -f "artifacts/coverage/**/*.xml" -t <Codecov upload token>
 ```
 
 You can see additional globbing patterns supported by codecov-exe by heading over to: https://github.com/kthompson/glob/#supported-pattern-expressions
+
+## MSBuild Integration
+
+Alternatively, you can use the [Codecov.MSBuild](https://www.nuget.org/packages/Codecov.MSBuild/) NuGet pacakge which provides the `Codecov` task for use in your project files.
+
+For example, to upload reports generated with the [coverlet.msbuild](https://github.com/coverlet-coverage/coverlet#msbuild-integration-suffers-of-possible-known-issue) task which produces the `CoverletReport` items:
+
+```xml
+<Target Name="UploadCoverageToCodecov" AfterTargets="GenerateCoverageResultAfterTest">
+  <Codecov ReportFiles="@(CoverletReport)" />
+</Target>
+```
+
+The only required parameter is `ReportFiles`, all other parameters are automatically guessed based on current environment variables and git repository status but you can override them if needed. See [Codecov.cs](https://github.com/codecov/codecov-exe/blob/master/Source/Codecov.MSBuild/Codecov.cs) for the complete list of supported parameters.
 
 ## Cake Addin
 

--- a/Source/Codecov.MSBuild/Codecov.MSBuild.csproj
+++ b/Source/Codecov.MSBuild/Codecov.MSBuild.csproj
@@ -1,0 +1,42 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>netstandard2.1</TargetFramework>
+        <IncludeBuildOutput>false</IncludeBuildOutput>
+        <NoWarn>NU5100;NU5128</NoWarn>
+        <Authors>admiringworm;mathphysics</Authors>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageProjectUrl>https://github.com/codecov/codecov-exe</PackageProjectUrl>
+        <PackageIconUrl>https://cdn.jsdelivr.net/gh/codecov/media@0953f4e0d5315fb6d526a248bc88e1bc16506a37/logos/pink.png</PackageIconUrl>
+        <Description>MSBuild task for uploading coverage reports to Codecov</Description>
+        <Copyright>Copyright (c) 2017-Present Larz White, Kim J. Nordmo</Copyright>
+        <PackageReleaseNotes>All release notes for Codecov can be found on the GitHub site - https://github.com/codecov/codecov-exe/releases/tag/$(Version)</PackageReleaseNotes>
+        <PackageTags>coverage;codecov;msbuild</PackageTags>
+        <RepositoryUrl>https://github.com/codecov/codecov-exe</RepositoryUrl>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Content Include="Codecov.MSBuild.targets" Pack="true" PackagePath="build/" />
+        <Content Include="$(OutputPath)/*.dll" Pack="true" PackagePath="task/" />
+        <Content Include="$(PkgSerilog)/lib/netstandard2.0/Serilog.dll" Pack="true" PackagePath="task/" Visible="false" />
+        <Content Include="$(PkgSerilog_Sinks_MSBuild)/lib/netstandard2.0/Serilog.Sinks.MSBuild.dll" Pack="true" PackagePath="task/" Visible="false" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Compile Include="../Codecov/**/*.cs" />
+        <Compile Remove="../Codecov/bin/**/*.cs" />
+        <Compile Remove="../Codecov/obj/**/*.cs" />
+        <Compile Remove="../Codecov/Coverage/Tool/Coverage.cs" />
+        <Compile Remove="../Codecov/Logging/LogConfiguration.cs" />
+        <Compile Remove="../Codecov/Program/CommandLineOptions.cs" />
+        <Compile Remove="../Codecov/Program/Program.cs" />
+        <Compile Remove="../Codecov/Program/Run.cs" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Build.Framework" Version="16.8.0" />
+        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.8.0" />
+        <PackageReference Include="Serilog" Version="2.10.0" GeneratePathProperty="true" />
+        <PackageReference Include="Serilog.Sinks.MSBuild" Version="1.3.0" GeneratePathProperty="true" />
+    </ItemGroup>
+</Project>

--- a/Source/Codecov.MSBuild/Codecov.MSBuild.targets
+++ b/Source/Codecov.MSBuild/Codecov.MSBuild.targets
@@ -1,0 +1,3 @@
+<Project>
+  <UsingTask TaskName="Codecov" AssemblyFile="$(MSBuildThisFileDirectory)../task/Codecov.MSBuild.dll" />
+</Project>

--- a/Source/Codecov.MSBuild/Codecov.cs
+++ b/Source/Codecov.MSBuild/Codecov.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Codecov.Coverage.EnviornmentVariables;
+using Codecov.Coverage.Report;
+using Codecov.Coverage.SourceCode;
+using Codecov.Coverage.Tool;
+using Codecov.Factories;
+using Codecov.Program;
+using Codecov.Services.VersionControlSystems;
+using Codecov.Upload;
+using Codecov.Url;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Serilog;
+using Serilog.Sinks.MSBuild;
+
+namespace Codecov.MSBuild
+{
+    /// <summary>
+    /// MSBuild task for uploading coverage reports to Codecov.
+    /// </summary>
+    public class Codecov : Task, IEnviornmentVariablesOptions, IHostOptions, IQueryOptions, IReportOptions, IVersionControlSystemOptions
+    {
+        /// <summary>
+        /// Gets or sets the report files to upload.
+        /// </summary>
+        [Required]
+        public ITaskItem[] ReportFiles { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying the environment variables to be included with this build.
+        /// </summary>
+        public string[] EnvironmentVariables { get; set; } = new string[0];
+
+        /// <summary>
+        /// Gets or sets a value used when not in git/hg project to identify project root directory.
+        /// </summary>
+        public string RepoRoot { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying the target url for Enterprise customers.
+        /// </summary>
+        public string Url { get; set; }
+
+        /// <summary>
+        /// Gets or sets a property specifying the branch name.
+        /// </summary>
+        public string Branch { get; set; }
+
+        /// <summary>
+        /// Gets or sets a property specifying the build number.
+        /// </summary>
+        public string Build { get; set; }
+
+        /// <summary>
+        /// Gets or sets a property specifying the commit sha.
+        /// </summary>
+        public string Commit { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying the flag the upload to group coverage metrics. See https://docs.codecov.io/docs/flags
+        /// </summary>
+        public string Flags { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying the custom defined name of the upload. Visible in Codecov UI.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying the pull request number.
+        /// </summary>
+        public string Pr { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying the owner/repo slug used instead of the private repo token in Enterprise.
+        /// </summary>
+        public string Slug { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying the git tag.
+        /// </summary>
+        public string Tag { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying the private repository token.
+        /// </summary>
+        public string Token { get; set; }
+
+        /// <summary>
+        /// Gets or sets the features to toggle on/off.
+        /// </summary>
+        public string[] Features { get; set; } = new string[0];
+
+        /// <summary>
+        /// Gets or sets a value disabling the upload of the file network.
+        /// </summary>
+        public bool DisableNetwork { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL at which the uploaded report can be viewed.
+        /// </summary>
+        [Output]
+        public string ReportUrl { get; set; }
+
+        /// <summary>
+        /// Execute the task.
+        /// </summary>
+        /// <returns><c>true</c> if the task executed successfully; otherwise, <c>false</c>.</returns>
+        public override bool Execute()
+        {
+            Serilog.Log.Logger = new LoggerConfiguration()
+                .Enrich.WithProperty(MSBuildProperties.Subcategory, nameof(Codecov))
+                .WriteTo.MSBuild(this)
+                .CreateLogger();
+            try
+            {
+                var reportFiles = ReportFiles.Select(e => new ReportFile(e.ItemSpec, File.ReadAllText(e.ItemSpec)));
+                var coverage = new Coverage(reportFiles);
+                var envVars = new EnviornmentVariables(this);
+                var continuousIntegrationServer = ContinuousIntegrationServerFactory.Create(envVars);
+                envVars.LoadEnviornmentVariables(continuousIntegrationServer);
+                var versionControlSystem = VersionControlSystemFactory.Create(this, new Terminal.Terminal());
+                var sourceCode = new SourceCode(versionControlSystem);
+                var yaml = new Yaml.Yaml(sourceCode);
+                var repositories = RepositoryFactory.Create(versionControlSystem, continuousIntegrationServer);
+                var url = new Url.Url(new Host(this, envVars), new Route(), new Query(this, repositories, continuousIntegrationServer, yaml, envVars));
+                var report = new Report(this, envVars, sourceCode, coverage);
+                var upload = new Uploads(url, report, Features);
+                var uploadFacade = new UploadFacade(continuousIntegrationServer, versionControlSystem, yaml, coverage, envVars, url, upload);
+                uploadFacade.LogContinuousIntegrationAndVersionControlSystem();
+                ReportUrl = uploadFacade.UploadReports();
+                return true;
+            }
+            catch (Exception exception)
+            {
+                Log.LogError("The Codecov MSBuild task failed.");
+                Log.LogErrorFromException(exception, showStackTrace: true);
+                return false;
+            }
+        }
+
+        IEnumerable<string> IEnviornmentVariablesOptions.Envs => EnvironmentVariables;
+    }
+}

--- a/Source/Codecov.MSBuild/Coverage.cs
+++ b/Source/Codecov.MSBuild/Coverage.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using Codecov.Coverage.Tool;
+
+namespace Codecov.MSBuild
+{
+    internal class Coverage : ICoverage
+    {
+        public Coverage(IEnumerable<ReportFile> coverageReports)
+        {
+            CoverageReports = coverageReports;
+        }
+
+        public IEnumerable<ReportFile> CoverageReports { get; }
+    }
+}

--- a/Source/Codecov.Tests/Coverage/EnviornmentVariables/EnviornmentVariablesTests.cs
+++ b/Source/Codecov.Tests/Coverage/EnviornmentVariables/EnviornmentVariablesTests.cs
@@ -38,7 +38,7 @@ namespace Codecov.Tests.Coverage.EnviornmentVariables
             var getEnviornmentVariables = enviornmentVariables.UserEnvironmentVariables;
 
             // Then
-            getEnviornmentVariables["CODECOV_ENV"].Should().Be("foo");
+            getEnviornmentVariables.Should().ContainKey("CODECOV_ENV").WhichValue.Should().Be("foo");
         }
 
         [Fact]
@@ -57,8 +57,8 @@ namespace Codecov.Tests.Coverage.EnviornmentVariables
             var getEnviornmentVariables = enviornmentVariables.UserEnvironmentVariables;
 
             // Then
-            getEnviornmentVariables["foo"].Should().Be("bar");
-            getEnviornmentVariables["fizz"].Should().Be("bizz");
+            getEnviornmentVariables.Should().ContainKey("foo").WhichValue.Should().Be("bar");
+            getEnviornmentVariables.Should().ContainKey("fizz").WhichValue.Should().Be("bizz");
         }
 
         [Fact]
@@ -77,8 +77,8 @@ namespace Codecov.Tests.Coverage.EnviornmentVariables
             var getEnviornmentVariables = enviornmentVariables.UserEnvironmentVariables;
 
             // Then
-            getEnviornmentVariables["foo"].Should().Be("bar");
-            getEnviornmentVariables["fizz"].Should().Be("bizz");
+            getEnviornmentVariables.Should().ContainKey("foo").WhichValue.Should().Be("bar");
+            getEnviornmentVariables.Should().ContainKey("fizz").WhichValue.Should().Be("bizz");
         }
     }
 }

--- a/Source/Codecov.sln
+++ b/Source/Codecov.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Codecov.Tests", "Codecov.Te
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Codecov.Tool", "Codecov.Tool\Codecov.Tool.csproj", "{D9701D7A-9FA1-4CCD-8357-A1FC8894918A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Codecov.MSBuild", "Codecov.MSBuild\Codecov.MSBuild.csproj", "{F1B636BC-F280-4DC6-BAD7-06E4729E95D6}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{391DE4D5-E7F1-45E4-85F3-5C43052D6D0A}"
 	ProjectSection(SolutionItems) = preProject
 		..\.editorconfig = ..\.editorconfig
@@ -32,6 +34,10 @@ Global
 		{D9701D7A-9FA1-4CCD-8357-A1FC8894918A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D9701D7A-9FA1-4CCD-8357-A1FC8894918A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D9701D7A-9FA1-4CCD-8357-A1FC8894918A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F1B636BC-F280-4DC6-BAD7-06E4729E95D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F1B636BC-F280-4DC6-BAD7-06E4729E95D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F1B636BC-F280-4DC6-BAD7-06E4729E95D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F1B636BC-F280-4DC6-BAD7-06E4729E95D6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/Codecov/Program/UploadFacade.cs
+++ b/Source/Codecov/Program/UploadFacade.cs
@@ -1,16 +1,10 @@
 using System;
-using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.RegularExpressions;
-using Codecov.Coverage.EnviornmentVariables;
-using Codecov.Coverage.Report;
-using Codecov.Coverage.SourceCode;
 using Codecov.Coverage.Tool;
-using Codecov.Factories;
-using Codecov.Services;
 using Codecov.Services.ContinuousIntegrationServers;
 using Codecov.Services.VersionControlSystems;
-using Codecov.Terminal;
 using Codecov.Upload;
 using Codecov.Url;
 using Codecov.Utilities;
@@ -19,54 +13,41 @@ using Serilog;
 
 namespace Codecov.Program
 {
+    [ExcludeFromCodeCoverage]
     internal class UploadFacade
     {
-        public UploadFacade(CommandLineOptions commandLineOptions)
+        private readonly IContinuousIntegrationServer _continuousIntegrationServer;
+        private readonly IVersionControlSystem _versionControlSystem;
+        private readonly IYaml _yaml;
+        private readonly ICoverage _coverage;
+        private readonly IEnviornmentVariables _enviornmentVariables;
+        private readonly IUrl _url;
+        private readonly IUpload _upload;
+
+        public UploadFacade(IContinuousIntegrationServer continuousIntegrationServer, IVersionControlSystem versionControlSystem, IYaml yaml, ICoverage coverage, IEnviornmentVariables enviornmentVariables, IUrl url, IUpload upload)
         {
-            CommandLineCommandLineOptions = commandLineOptions;
-            var envVars = new EnviornmentVariables(commandLineOptions);
-            ContinuousIntegrationServer = ContinuousIntegrationServerFactory.Create(envVars);
-            envVars.LoadEnviornmentVariables(ContinuousIntegrationServer);
-            EnviornmentVariables = envVars;
+            _continuousIntegrationServer = continuousIntegrationServer;
+            _versionControlSystem = versionControlSystem;
+            _yaml = yaml;
+            _coverage = coverage;
+            _enviornmentVariables = enviornmentVariables;
+            _url = url;
+            _upload = upload;
         }
-
-        private static IDictionary<TerminalName, ITerminal> Terminals => TerminalFactory.Create();
-
-        private ICoverage Coverage => new Coverage.Tool.Coverage(CommandLineCommandLineOptions);
-
-        private IUrl Url => new Url.Url(new Host(CommandLineCommandLineOptions, EnviornmentVariables), new Route(), new Query(CommandLineCommandLineOptions, Repositories, ContinuousIntegrationServer, Yaml, EnviornmentVariables));
-
-        private IYaml Yaml => new Yaml.Yaml(SourceCode);
-
-        private CommandLineOptions CommandLineCommandLineOptions { get; }
-
-        private IContinuousIntegrationServer ContinuousIntegrationServer { get; }
 
         private string DisplayUrl
         {
             get
             {
-                var url = Url.GetUrl.ToString();
+                var url = _url.GetUrl.ToString();
                 var regex = new Regex(@"token=\w{8}-\w{4}-\w{4}-\w{4}-\w{12}&");
                 return regex.Replace(url, string.Empty);
             }
         }
 
-        private IEnviornmentVariables EnviornmentVariables { get; }
-
-        private IReport Report => new Report(CommandLineCommandLineOptions, EnviornmentVariables, SourceCode, Coverage);
-
-        private IEnumerable<IRepository> Repositories => RepositoryFactory.Create(VersionControlSystem, ContinuousIntegrationServer);
-
-        private ISourceCode SourceCode => new SourceCode(VersionControlSystem);
-
-        private IUpload Upload => new Uploads(Url, Report, CommandLineCommandLineOptions.Features);
-
-        private IVersionControlSystem VersionControlSystem => VersionControlSystemFactory.Create(CommandLineCommandLineOptions, Terminals[TerminalName.Generic]);
-
-        public void Uploader()
+        public void LogContinuousIntegrationAndVersionControlSystem()
         {
-            var ci = ContinuousIntegrationServer.GetType().Name;
+            var ci = _continuousIntegrationServer.GetType().Name;
             if (ci.Equals("ContinuousIntegrationServer"))
             {
                 Log.Warning("No CI detected.");
@@ -74,7 +55,7 @@ namespace Codecov.Program
             else if (ci.Equals("TeamCity"))
             {
                 Log.Information("{ci} detected.", ci);
-                if (string.IsNullOrWhiteSpace(ContinuousIntegrationServer.Branch))
+                if (string.IsNullOrWhiteSpace(_continuousIntegrationServer.Branch))
                 {
                     Log.Warning("Teamcity does not automatically make build parameters available as environment variables.\nAdd the following environment parameters to the build configuration.\nenv.TEAMCITY_BUILD_BRANCH = %teamcity.build.branch%.\nenv.TEAMCITY_BUILD_ID = %teamcity.build.id%.\nenv.TEAMCITY_BUILD_URL = %teamcity.serverUrl%/viewLog.html?buildId=%teamcity.build.id%.\nenv.TEAMCITY_BUILD_COMMIT = %system.build.vcs.number%.\nenv.TEAMCITY_BUILD_REPOSITORY = %vcsroot.<YOUR TEAMCITY VCS NAME>.url%.");
                 }
@@ -84,7 +65,7 @@ namespace Codecov.Program
                 Log.Information("{ci} detected.", ci);
             }
 
-            var vcs = VersionControlSystem.GetType().Name;
+            var vcs = _versionControlSystem.GetType().Name;
             if (vcs.Equals("VersionControlSystem"))
             {
                 Log.Warning("No VCS detected.");
@@ -94,51 +75,48 @@ namespace Codecov.Program
                 Log.Information("{vcs} detected.", vcs);
             }
 
-            Log.Information("Project root: {RepoRoot}", VersionControlSystem.RepoRoot);
-            if (string.IsNullOrWhiteSpace(Yaml.FileName))
+            Log.Information("Project root: {RepoRoot}", _versionControlSystem.RepoRoot);
+            if (string.IsNullOrWhiteSpace(_yaml.FileName))
             {
                 Log.Information("Yaml not found, that's ok! Learn more at {CodecovUrl}", "https://docs.codecov.io/docs/codecov-yaml");
             }
 
             Log.Information("Reading reports.");
-            Log.Information(string.Join("\n", Coverage.CoverageReports.Select(x => x.File)));
+            Log.Information(string.Join("\n", _coverage.CoverageReports.Select(x => x.File)));
 
-            if (EnviornmentVariables.UserEnvironmentVariables.Any())
+            if (_enviornmentVariables.UserEnvironmentVariables.Any())
             {
                 Log.Information("Appending build variables");
-                Log.Information(string.Join("\n", EnviornmentVariables.UserEnvironmentVariables.Select(x => x.Key.Trim()).ToArray()));
+                Log.Information(string.Join("\n", _enviornmentVariables.UserEnvironmentVariables.Select(x => x.Key.Trim()).ToArray()));
             }
+        }
 
-            if (CommandLineCommandLineOptions.Dump)
-            {
-                Log.Warning("Skipping upload and dumping contents.");
-                Log.Information("url: {GetUrl}", Url.GetUrl);
-                Log.Information(Report.Reporter);
-                return;
-            }
-
+        public string UploadReports()
+        {
             // We warn if the total file size is above 20 MB
-            var fileSizes = Coverage.CoverageReports.Sum(x => FileSystem.GetFileSize(x.File));
+            var fileSizes = _coverage.CoverageReports.Sum(x => FileSystem.GetFileSize(x.File));
             if (fileSizes > 20_971_520)
             {
-                Log.Warning("Total file size of reports is above 20MB, this may prevent report being shown on {Host}", Url.GetUrl.Host);
+                Log.Warning("Total file size of reports is above 20MB, this may prevent report being shown on {Host}", _url.GetUrl.Host);
                 Log.Warning("Reduce the total upload size if this occurs");
             }
 
             Log.Information("Uploading Reports.");
-            Log.Information("url: {Scheme}://{Authority}", Url.GetUrl.Scheme, Url.GetUrl.Authority);
+            Log.Information("url: {Scheme}://{Authority}", _url.GetUrl.Scheme, _url.GetUrl.Authority);
             Log.Information("query: {DisplayUrl}", DisplayUrl);
 
-            var response = Upload.Uploader();
+            var response = _upload.Uploader();
             Log.Verbose("response: {response}", response);
             var splitResponse = response.Split('\n');
             if (splitResponse.Length > 1)
             {
                 var s3 = new Uri(splitResponse[1]);
-                var reportUrl = splitResponse[0];
                 Log.Information("Uploading to S3 {Scheme}://{Authority}", s3.Scheme, s3.Authority);
-                Log.Information("View reports at: {reportUrl}", reportUrl);
             }
+
+            var reportUrl = splitResponse[0];
+            Log.Information("View reports at: {reportUrl}", reportUrl);
+            return reportUrl;
         }
     }
 }

--- a/build/packaging.cake
+++ b/build/packaging.cake
@@ -89,6 +89,22 @@ var createDotNetToolTask = Task("Create-DotNetToolPackage")
     });
 });
 
+var createMSBuildTaskPackageTask = Task("Create-MSBuildTaskPackage")
+    .IsDependentOn(buildTask)
+    .Does<BuildData>((data) =>
+{
+    var output = data.Directories.Packages.Combine("dotnet");
+
+    DotNetCorePack("./Source/Codecov.MSBuild", new DotNetCorePackSettings {
+        Configuration = data.Configuration,
+        NoBuild = true,
+        NoRestore = true,
+        OutputDirectory = output,
+        MSBuildSettings = data.MSBuildSettings,
+        IncludeSymbols = true,
+    });
+});
+
 var createNuGetPackagesTask = Task("Create-NuGetPackages")
     .WithCriteria(buildNuget)
     .IsDependentOn(createExecsTask)
@@ -109,5 +125,6 @@ var createNuGetPackagesTask = Task("Create-NuGetPackages")
 
 var createPackagesTask = Task("Create-Packages")
     .IsDependentOn(createDotNetToolTask)
+    .IsDependentOn(createMSBuildTaskPackageTask)
     .IsDependentOn(createNuGetPackagesTask)
     .IsDependentOn(createChocolateyPackagesTask);

--- a/setup.cake
+++ b/setup.cake
@@ -28,7 +28,8 @@ Task("Default")
     .IsDependentOn("Cleanup")
     .IsDependentOn(testTask)
     .IsDependentOn(createExecsTask)
-    .IsDependentOn(createDotNetToolTask);
+    .IsDependentOn(createDotNetToolTask)
+    .IsDependentOn(createMSBuildTaskPackageTask);
 
 Task("CI")
     .IsDependentOn("Default")


### PR DESCRIPTION
* Refactored the `UploadFacade` class to depend on interfaces instead of CommandLineOptions so that it's usable from the MSBuild task
* Added documentation in the README about the new `Codecov.MSBuild` package
* Updated Cake scripts to handle the new `Codecov.MSBuild` package