### PR TITLE
Use built-in args handling when launching processes

### DIFF
--- a/Source/Codecov.Tests/Services/VersionControlSystems/GitTests.cs
+++ b/Source/Codecov.Tests/Services/VersionControlSystems/GitTests.cs
@@ -17,7 +17,7 @@ namespace Codecov.Tests.Services.VersionControlSystems
         {
             // Given
             var terminal = Substitute.For<ITerminal>();
-            terminal.Run("git", $@"-C ""{Directory.GetCurrentDirectory()}"" rev-parse --abbrev-ref HEAD").Returns("develop");
+            terminal.Run("git", "-C", Directory.GetCurrentDirectory(), "rev-parse", "--abbrev-ref", "HEAD").Returns("develop");
             var options = Substitute.For<IVersionControlSystemOptions>();
             var git = new Git(options, terminal);
 
@@ -33,7 +33,7 @@ namespace Codecov.Tests.Services.VersionControlSystems
         {
             // Given
             var terminal = Substitute.For<ITerminal>();
-            terminal.Run("git", $@"-C ""{Directory.GetCurrentDirectory()}"" rev-parse --abbrev-ref HEAD").Returns(branchData);
+            terminal.Run("git", "-C", Directory.GetCurrentDirectory(), "rev-parse", "--abbrev-ref", "HEAD").Returns(branchData);
             var options = Substitute.For<IVersionControlSystemOptions>();
             var git = new Git(options, terminal);
 
@@ -49,7 +49,7 @@ namespace Codecov.Tests.Services.VersionControlSystems
         {
             // Given
             var terminal = Substitute.For<ITerminal>();
-            terminal.Run("git", $@"-C ""{Directory.GetCurrentDirectory()}"" rev-parse HEAD").Returns("11");
+            terminal.Run("git", "-C", Directory.GetCurrentDirectory(), "rev-parse", "HEAD").Returns("11");
             var options = Substitute.For<IVersionControlSystemOptions>();
             var git = new Git(options, terminal);
 
@@ -65,7 +65,7 @@ namespace Codecov.Tests.Services.VersionControlSystems
         {
             // Given
             var terminal = Substitute.For<ITerminal>();
-            terminal.Run("git", $@"-C ""{Directory.GetCurrentDirectory()}"" rev-parse HEAD").Returns(commitData);
+            terminal.Run("git", "-C", Directory.GetCurrentDirectory(), "rev-parse", "HEAD").Returns(commitData);
             var options = Substitute.For<IVersionControlSystemOptions>();
             var git = new Git(options, terminal);
 
@@ -137,7 +137,7 @@ namespace Codecov.Tests.Services.VersionControlSystems
         {
             // Given
             var terminal = Substitute.For<ITerminal>();
-            terminal.Run("git", "rev-parse --show-toplevel").Returns(terminalData);
+            terminal.Run("git", "rev-parse", "--show-toplevel").Returns(terminalData);
             var options = Substitute.For<IVersionControlSystemOptions>();
             options.RepoRoot.Returns(string.Empty);
             var git = new Git(options, terminal);
@@ -155,7 +155,7 @@ namespace Codecov.Tests.Services.VersionControlSystems
             // Given
             var rootDir = Path.Combine(_systemDrive, "Fake");
             var terminal = Substitute.For<ITerminal>();
-            terminal.Run("git", "rev-parse --show-toplevel").Returns(rootDir);
+            terminal.Run("git", "rev-parse", "--show-toplevel").Returns(rootDir);
             var options = Substitute.For<IVersionControlSystemOptions>();
             options.RepoRoot.Returns(optionsData);
             var git = new Git(options, terminal);
@@ -189,7 +189,7 @@ namespace Codecov.Tests.Services.VersionControlSystems
         {
             // Given
             var terminal = Substitute.For<ITerminal>();
-            terminal.Run("git", $@"-C ""{Directory.GetCurrentDirectory()}"" ls-tree --full-tree -r HEAD --name-only").Returns("Class.cs");
+            terminal.Run("git", "-C", Directory.GetCurrentDirectory(), "ls-tree", "--full-tree", "-r", "HEAD", "--name-only").Returns("Class.cs");
             var options = Substitute.For<IVersionControlSystemOptions>();
             var git = new Git(options, terminal);
 
@@ -207,7 +207,7 @@ namespace Codecov.Tests.Services.VersionControlSystems
         {
             // Given
             var terminal = Substitute.For<ITerminal>();
-            terminal.Run("git", $@"-C ""{Directory.GetCurrentDirectory()}"" ls-tree --full-tree -r HEAD --name-only").Returns(terminalData);
+            terminal.Run("git", "-C", Directory.GetCurrentDirectory(), "ls-tree", "--full-tree", "-r", "HEAD", "--name-only").Returns(terminalData);
             var options = Substitute.For<IVersionControlSystemOptions>();
             var git = new Git(options, terminal);
 
@@ -227,7 +227,7 @@ namespace Codecov.Tests.Services.VersionControlSystems
         {
             // Given
             var terminal = Substitute.For<ITerminal>();
-            terminal.Run("git", $@"-C ""{Directory.GetCurrentDirectory()}"" ls-tree --full-tree -r HEAD --name-only").Returns(terminalData);
+            terminal.Run("git", "-C", Directory.GetCurrentDirectory(), "ls-tree", "--full-tree", "-r", "HEAD", "--name-only").Returns(terminalData);
             var options = Substitute.For<IVersionControlSystemOptions>();
             var git = new Git(options, terminal);
 
@@ -243,7 +243,7 @@ namespace Codecov.Tests.Services.VersionControlSystems
         {
             // Given
             var terminal = Substitute.For<ITerminal>();
-            terminal.Run("git", $@"-C ""{Directory.GetCurrentDirectory()}"" config --get remote.origin.url").Returns(slugData);
+            terminal.Run("git", "-C", Directory.GetCurrentDirectory(), "config", "--get", "remote.origin.url").Returns(slugData);
             var options = Substitute.For<IVersionControlSystemOptions>();
             var git = new Git(options, terminal);
 
@@ -259,7 +259,7 @@ namespace Codecov.Tests.Services.VersionControlSystems
         {
             // Given
             var terminal = Substitute.For<ITerminal>();
-            terminal.Run("git", $@"-C ""{Directory.GetCurrentDirectory()}"" config --get remote.origin.url").Returns(slugData);
+            terminal.Run("git", "-C", Directory.GetCurrentDirectory(), "config", "--get", "remote.origin.url").Returns(slugData);
             var options = Substitute.For<IVersionControlSystemOptions>();
             var git = new Git(options, terminal);
 
@@ -275,7 +275,7 @@ namespace Codecov.Tests.Services.VersionControlSystems
         {
             // Given
             var terminal = Substitute.For<ITerminal>();
-            terminal.Run("git", $@"-C ""{Directory.GetCurrentDirectory()}"" ls-tree --full-tree -r HEAD --name-only").Returns(terminalData);
+            terminal.Run("git", "-C", Directory.GetCurrentDirectory(), "ls-tree", "--full-tree", "-r", "HEAD", "--name-only").Returns(terminalData);
             var options = Substitute.For<IVersionControlSystemOptions>();
             var git = new Git(options, terminal);
 

--- a/Source/Codecov/Services/VersionControlSystems/Git.cs
+++ b/Source/Codecov/Services/VersionControlSystems/Git.cs
@@ -41,7 +41,7 @@ namespace Codecov.Services.VersionControlSystems
 
         private string LoadBranch()
         {
-            var branch = RunGit(@"rev-parse --abbrev-ref HEAD");
+            var branch = RunGit(@"rev-parse", "--abbrev-ref", "HEAD");
             return string.IsNullOrWhiteSpace(branch) || branch.Equals("HEAD")
                 ? string.Empty
                 : branch;
@@ -49,7 +49,7 @@ namespace Codecov.Services.VersionControlSystems
 
         private string LoadCommit()
         {
-            var commit = RunGit(@"rev-parse HEAD");
+            var commit = RunGit(@"rev-parse", "HEAD");
             return !string.IsNullOrWhiteSpace(commit) ? commit : string.Empty;
         }
 
@@ -64,13 +64,13 @@ namespace Codecov.Services.VersionControlSystems
                 return FileSystem.NormalizedPath(Options.RepoRoot);
             }
 
-            var root = Terminal.Run("git", "rev-parse --show-toplevel");
+            var root = Terminal.Run("git", "rev-parse", "--show-toplevel");
             return string.IsNullOrWhiteSpace(root) ? FileSystem.NormalizedPath(".") : FileSystem.NormalizedPath(root);
         }
 
         private string LoadSlug()
         {
-            var remote = RunGit("config --get remote.origin.url");
+            var remote = RunGit("config", "--get", "remote.origin.url");
 
             if (string.IsNullOrWhiteSpace(remote))
             {
@@ -93,12 +93,13 @@ namespace Codecov.Services.VersionControlSystems
 
         private IEnumerable<string> LoadSourceCode()
         {
-            var sourceCode = RunGit("ls-tree --full-tree -r HEAD --name-only");
+            var sourceCode = RunGit("ls-tree", "--full-tree", "-r", "HEAD", "--name-only");
             return string.IsNullOrWhiteSpace(sourceCode) ?
                 Enumerable.Empty<string>()
                 : sourceCode.Trim('\n').Split('\n').Select(file => FileSystem.NormalizedPath(Path.Combine(RepoRoot, file)));
         }
 
-        private string RunGit(string commandArguments) => Terminal.Run("git", $@"-C ""{RepoRoot}"" {commandArguments}");
+        private string RunGit(params string[] commandArguments) =>
+            Terminal.Run("git", new[] { "-C", RepoRoot }.Concat(commandArguments).ToArray());
     }
 }

--- a/Source/Codecov/Terminal/ITerminal.cs
+++ b/Source/Codecov/Terminal/ITerminal.cs
@@ -4,7 +4,7 @@
     {
         bool Exits { get; }
 
-        string Run(string command, string commandArguments);
+        string Run(string command, params string[] commandArguments);
 
         string RunScript(string script);
     }

--- a/Source/Codecov/Terminal/Terminal.cs
+++ b/Source/Codecov/Terminal/Terminal.cs
@@ -10,18 +10,24 @@ namespace Codecov.Terminal
     {
         public virtual bool Exits => true;
 
-        public virtual string Run(string command, string commandArguments)
+        public virtual string Run(string command, params string[] commandArguments)
         {
             try
             {
                 using (var process = new Process())
                 {
-                    process.StartInfo = new ProcessStartInfo(command.Trim(), commandArguments.Trim())
+                    process.StartInfo = new ProcessStartInfo
                     {
+                        FileName = command.Trim(),
                         UseShellExecute = false,
                         RedirectStandardOutput = true,
                         RedirectStandardError = true
                     };
+
+                    foreach (var arg in commandArguments)
+                    {
+                        process.StartInfo.ArgumentList.Add(arg);
+                    }
 
                     var output = new StringBuilder();
                     var error = new StringBuilder();


### PR DESCRIPTION
This PR improves how arguments are specified when processes, like `git`, are spawned. Instead of specifying the entire command-line arguments as a single string, I have updated the code to specify arguments as a variable (`params`) array of strings. `Terminal.Run` then loads them into the new [`ProcessStartInfo.ArgumentList`](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.argumentlist?view=netcore-3.1#System_Diagnostics_ProcessStartInfo_ArgumentList) (available since .NET Core 2.1). The benefit of doing this is that the code is more portable as one doesn't have to worry about the escaping & quoting rules of each platform.
